### PR TITLE
use individual lodash modules

### DIFF
--- a/ampersand-app.js
+++ b/ampersand-app.js
@@ -1,7 +1,7 @@
 /*$AMPERSAND_VERSION*/
 var Events = require('ampersand-events');
-var toArray = require('lodash/toArray');
-var extend = require('lodash/assign');
+var toArray = require('lodash.toarray');
+var extend = require('lodash.assign');
 
 
 // instance app, can be used just by itself

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "dependencies": {
     "ampersand-events": "^2.0.1",
     "ampersand-version": "^1.0.2",
-    "lodash": "^4.11.1"
+    "lodash.assign": "^4.2.0",
+    "lodash.toarray": "^4.4.0"
   },
   "browserify": {
     "transform": [
@@ -33,8 +34,9 @@
     ]
   },
   "devDependencies": {
+    "lodash.keys": "^4.2.0",
     "phantomjs": "^2.1.7",
     "tape": "^4.5.1",
-    "zuul": "^3.9.0"
+    "zuul": "^3.11.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 var test = require('tape');
 var app = require('../ampersand-app');
 var Events = require('ampersand-events');
-var objKeys = require('lodash/keys');
+var objKeys = require('lodash.keys');
 
 
 test('ampersand-app basic functionality', function (t) {


### PR DESCRIPTION
Was doing an audit of one of my apps this week and noticed this module was bringing in ALL of lodash with it, that's > 200k of code I don't need, personally.

Not sure if there was a specific reason or bringing it in but this PR takes it back to the single-repo-per-method we were doing w/ lodash 3.
